### PR TITLE
Very small fix for NumberSequence and ColorSequence in PROP module

### DIFF
--- a/src/Chunks/PROP.lua
+++ b/src/Chunks/PROP.lua
@@ -262,7 +262,7 @@ local function PROP(chunk: Types.Chunk, rbxm: Types.Rbxm)
 			local kpCount = reader:readNumber("<I4")
 			local kp = table.create(kpCount)
 
-			for i = 1, kp do
+			for i = 1, kpCount do
 				table.insert(kp, NumberSequenceKeypoint.new(
 					reader:readNumber("<f"),
 					reader:readNumber("<f"),
@@ -279,7 +279,7 @@ local function PROP(chunk: Types.Chunk, rbxm: Types.Rbxm)
 			local kpCount = reader:readNumber("<I4")
 			local kp = table.create(kpCount)
 
-			for i = 1, kp do
+			for i = 1, kpCount do
 				table.insert(kp, ColorSequenceKeypoint.new(
 					reader:readNumber("<f"),
 					Color3.new(


### PR DESCRIPTION
Yeah you were supposed to use the kpCount and not the kp table itself

If you want, you could just do 

```
local kp = table.create(reader:readNumber("<I4"))

for _ in kp do
```
Since you are not using the "i" value at all